### PR TITLE
Cleaning up requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,23 @@
-Click==7.0
 Flask==1.1.1
+
+# Flask dependencies
+Click==7.0
 itsdangerous==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.1
-Pillow==6.1.0
-Pillow-PIL==0.1.dev0
-psycopg2-binary==2.8.3
-simplepam==0.1.5
 Werkzeug==0.15.6
+
+# Used for postgres connections
+psycopg2-binary==2.8.3
+
+
+# Used for the dashboard authentication 
+simplepam==0.1.5
+
+# Used for images
+Pillow-PIL==0.1.dev0
+
+# Required for GCP auth regarding Datathons
 oauth2client==4.1.3
 pyOpenSSL==19.0.0
 google-api-python-client==1.7.11


### PR DESCRIPTION
I am just cleaning the requirements and removing pillow since its not needed.

We will have to see where/how/if we are going to continue with the datathons since there is a management page for access to GCP groups for datathons. If we wont use it we can remove it and the requirements from here also. 