### PR TITLE
Modifies footer

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -27,7 +27,7 @@
     text-decoration: underline;
     cursor: pointer;
 } */
-.footer_menu1 ul li a {
+.footer_menu_pub ul li a {
     color: #9E9E9E; 
 }
 .about {
@@ -245,7 +245,7 @@
     padding: 1.875em 0em 50px;
     border-bottom: 0.0625em solid #0F0F0F;
     background: none repeat scroll 0% 0% #333;
-    color: #AAA;
+    color: #9E9E9E;
 }
 .footer_b {
     background: #222; 
@@ -285,7 +285,6 @@
     margin-top: 1.25em;
 }
 .footer_menu ul li a {
-    text-decoration: none;
     color: #9E9E9E;
     display: inline-block;
     padding: 0.3125em 0em;
@@ -295,9 +294,6 @@
 }
 .footer_menu_contact li i{
     width: 1.25em;
-}
-.footer_menu_contact li span:hover {
-    cursor:pointer;
 }
 .profile-bio {
     padding-top: 2.5em;

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -3,9 +3,9 @@
     <div class="row">
       <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
         <h2 class="menu_head" >Recent publications</h2>
-        <div class="footer_menu1">
+        <div class="footer_menu_pub">
           <ul id="News" style='list-style: square outside;'>
-              {% include 'recent_publications.html'%}
+            {% include 'recent_publications.html'%}
           </ul>
         </div>
       </div>
@@ -15,7 +15,6 @@
           <ul id="Links" style='list-style: none;list-style-position: inside; padding-left: 0;'>
             <li><a href="https://physionet.org">PhysioNet Website</a></li>
             <li><a href="https://mimic.physionet.org">MIMIC Website</a></li>
-            <li><a href="https://querybuilder-lcp.mit.edu">Query Builder</a></li>
             <li><a href="http://sana.mit.edu/">Sana Website</a></li>
             <li><a href="http://criticaldata.mit.edu/">Critical Data Website</a></li>
           </ul>
@@ -26,28 +25,22 @@
         <div class="footer_menu_contact">
           <ul style='list-style: none;'>
             <li>
-              <i class="fa fa-home"></i>
-              <span>Laboratory for Computational Physiology <br> MIT, E25-505 <br> 45 Carleton St. <br> Cambridge, MA 02139 <br></span>
+              <span>
+                Laboratory for Computational Physiology<br>
+                MIT, E25-505<br>
+                45 Carleton St.<br>
+                Cambridge, MA 02139
+              </span>
             </li>
-<!--             <li><i class="fa fa-envelope"></i>contact&lt;AT&gt;lcp.mit.edu</li>
- -->
-            <li><i class="fa fa-envelope"></i>contact@lcp.mit.edu</li>
-             <li>
-            <a href="https://github.com/MIT-LCP" style="padding-right:10px;color:#337ab7;"><i class="fa fa-github fa-2x" ></i></a>
-            <a href="https://twitter.com/mitcriticaldata" style="padding-right:10px;color:#337ab7;"><i class="fa fa-twitter fa-2x"></i></a>
-            <a href="https://www.instagram.com/mitcriticaldata" style="padding-right:10px;color:#337ab7;"><i class="fa fa-instagram fa-2x"></i></a></li>
+            <li>
+              <a href="mailto: contact@lcp.mit.edu">
+              <i class="fa fa-envelope"></i>contact@lcp.mit.edu</a>
+            </li>
+            <li>
+              <a href="https://github.com/MIT-LCP">
+              <i class="fa fa-github"></i>Official Github Page</a>
+            </li>
           </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="footer_b">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-6 col-sm-6 col-xs-12">
-        <div class="footer_bottom">
-          <p class="text-block"> © Copyright reserved to <span>LCP </span></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Modifies footer to remove the links to the twitter and instagram page for MIT Critical Data, remove the link to Query Builder, and remove the bottom copyright notice. Some other minor formatting changes were made for consistency.