### PR TITLE
Fixes Publications Page

### DIFF
--- a/static/css/publications.css
+++ b/static/css/publications.css
@@ -56,6 +56,9 @@ ul.bib2xhtml li {
     font-weight: bolder;
     color: #000;
 }
-a {
-    color: #202123;
+.nav-tabs .nav-link {
+    border: none;
+}
+.nav-tabs .nav-link:hover {
+    font-weight: bolder;
 }


### PR DESCRIPTION
Fixes the non-blue links at the bottom of the Publications page. Also makes the links in the references visible so the user knows that there are links there. Further, improves the design of the navbar on the left side.