### PR TITLE
add link to news page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,8 +30,8 @@
               <strong class="d-inline-block mb-2 text-success">{{ post.header }}</strong>
               <h3 class="mb-0">{{ post.title }}</h3>
               <div class="mb-1 text-muted">{{ post.date }}</div>
-              <p class="card-text mb-auto">{{ post.content | safe | truncate(150)}}</p>
-              <!-- <a href="news#" class="stretched-link">Continue reading</a> -->
+              <p class="card-text">{{ post.content | safe | truncate(200)}}</p>
+              <a href="/news" class="card-link">Continue reading</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Minor change to the front page of the website to:

- add a link from news items to the news page.
- truncate news items at 200 characters, instead of 150 (felt a little too short before with the news items i was looking at).

