### PR TITLE
Align the "contact" header with the text below

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -24,26 +24,12 @@
       </div>
       <div class="col-md-4 col-sm-6 col-xs-12">
         <h2 class="menu_head">Contact Us</h2>
-        <div class="footer_menu_contact">
-          <ul style='list-style: none;'>
-            <li>
-              <span>
-                Laboratory for Computational Physiology<br>
-                MIT, E25-505<br>
-                45 Carleton St.<br>
-                Cambridge, MA 02139
-              </span>
-            </li>
-            <li>
-              <a href="mailto: contact@lcp.mit.edu">
-              <i class="fa fa-envelope"></i>contact@lcp.mit.edu</a>
-            </li>
-            <li>
-              <a href="https://github.com/MIT-LCP">
-              <i class="fa fa-github"></i>Official Github Page</a>
-            </li>
-          </ul>
-        </div>
+        <p>Laboratory for Computational Physiology<br>
+        MIT, E25-505<br>
+        45 Carleton St.<br>
+        Cambridge, MA 02139</p>
+        <p><a href="mailto: contact@lcp.mit.edu"><i class="fa fa-envelope">&nbsp;</i>contact@lcp.mit.edu</a><br>
+        <a href="https://github.com/MIT-LCP"><i class="fa fa-github">&nbsp;</i>Github</a></p>
       </div>
     </div>
   </div>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -28,7 +28,7 @@
         MIT, E25-505<br>
         45 Carleton St.<br>
         Cambridge, MA 02139</p>
-        <p><a href="mailto: contact@lcp.mit.edu"><i class="fa fa-envelope">&nbsp;</i>contact@lcp.mit.edu</a><br>
+        <p><a href="mailto:contact@lcp.mit.edu"><i class="fa fa-envelope">&nbsp;</i>contact@lcp.mit.edu</a><br>
         <a href="https://github.com/MIT-LCP"><i class="fa fa-github">&nbsp;</i>Github</a></p>
       </div>
     </div>


### PR DESCRIPTION
Couple of very minor changes in the footer:

- Left aligns the "Contact" header with the content of the column
- Fixes the mailto: link so that it validates on the W3C checker (removes a space).
- Changes "Official GitHub page" to "GitHub"

![Screen Shot 2020-09-02 at 10 34 34](https://user-images.githubusercontent.com/822601/91997511-28e77480-ed08-11ea-8492-924b1c550aca.png)
