### PR TITLE
Minor fixes for W3C validation

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -22,8 +22,7 @@
   <div class="row">
     <div class="col-md-9">
 
-      <a name="Summary"></a>
-      <h2 class="site-section-meta border-bottom">Research Summary</h2>
+      <h2 class="site-section-meta border-bottom" id="Summary">Research Summary</h2>
       <p>
         The Laboratory for Computational Physiology (LCP), under the direction of Professor Roger Mark, conducts research on improving health care through new and refined approaches to interpreting data.
         Some of the group’s researchers have medical backgrounds; others have backgrounds in computer science, electrical engineering, physics, or mathematics; and others have training that spans several of these disciplines.
@@ -33,16 +32,14 @@
         Current laboratory research comprises two major projects, the <a href="mimic">MIMIC</a> project and <a href="physionet">PhysioNet</a>. See their respective pages for more detailed information.
       </p>
 
-      <a name="Joining"></a>
-      <h2 class="site-section-meta border-bottom">Joining the Lab</h2>
+      <h2 class="site-section-meta border-bottom" id="Joining">Joining the Lab</h2>
       <p>
         The Laboratory for Computational Physiology offers research opportunities to MIT students, including UROPs for undergraduate students and thesis projects for graduate students.
         A degree is required of anyone outside of the MIT community interested in collaborating with the laboratory.
         For those with a degree interested in collaborating with the laboratory, please <a href="#Contact">contact us</a>.
       </p>
 
-      <a name="Contact"></a>
-      <h2 class="site-section-meta border-bottom">Contact</h2>
+      <h2 class="site-section-meta border-bottom" id="Contact">Contact</h2>
       <div class="col-md-9">
         <div class="row">
           <div class="col-md-6">

--- a/templates/mimic.html
+++ b/templates/mimic.html
@@ -20,14 +20,12 @@
   <div class="row">
     <div class="col-md-9">
 
-      <a name="Overview"></a>
-      <h2 class="site-section-meta border-bottom">Overview</h2>
+      <h2 class="site-section-meta border-bottom" id="Overview">Overview</h2>
       <p>
         MIMIC is a publicly available dataset developed by the Laboratory for Computational Physiology that comprises deidentified health data associated with thousands of intensive care unit admissions. The dataset is widely used by investigators and engineers around the world, helping to drive research in clinical informatics, epidemiology, and machine learning.
       </p>
 
-      <a name="Story"></a>
-      <h2 class="site-section-meta border-bottom">Story of MIMIC</h2>
+      <h2 class="site-section-meta border-bottom" id="Story">Story of MIMIC</h2>
       <p>
       In the early 2000s, with colleagues from academia (Massachusetts Institute of Technology), industry (Philips Medical Systems), and clinical medicine (Beth Israel Deaconess Medical Center, BIDMC) we received NIH (National Institutes of Health) funding to launch the project “Integrating Signals, Models and Reasoning in Critical Care”, a major goal of which was to build a massive critical care research database. The study was approved by the Institutional Review Boards of BIDMC (Boston, MA) and MIT (Cambridge, MA). 
       </p>
@@ -41,8 +39,7 @@
       These data were de-identified in compliance with Health Insurance Portability and Accountability Act standards, and restructured to facilitate reuse in scientific research. The assembled dataset, MIMIC, is shared via the PhysioNet. To restrict users to legitimate medical researchers, access to the clinical database requires completion of a simple data use agreement (DUA) and proof that the researcher has completed human subjects training.
       </p>
 
-      <a name="Future"></a>
-      <h2 class="site-section-meta border-bottom">Future Directions</h2>
+      <h2 class="site-section-meta border-bottom" id="Future">Future Directions</h2>
       <p>
         The MIMIC database is a powerful and flexible research resource, but the generalizability of MIMIC-based studies is somewhat limited by the fact that the data are collected from a single institution. Multi-center data would have the advantages of including wider practice variability, and of course a larger number of cases. Data from international institutions would add still greater strength to the database owing to the even larger variations in practice and patient populations.
       </p>
@@ -50,8 +47,7 @@
       Our long-term goal is to expand our work to enable incorporate data from multiple institutions, capable of supporting research on cohorts of critically ill patients from around the world. In addition, we seek to expand the data to new modalities, including x-ray images and echocardiograms.
       </p>
 
-      <a name="Acknowledgments"></a>
-      <h2 class="site-section-meta border-bottom">Acknowledgments</h2>
+      <h2 class="site-section-meta border-bottom" id="Acknowledgments">Acknowledgments</h2>
       <p>
         The development and maintenance of MIMIC has been funded by the National Institute of Biomedical Imaging and Bioengineering (NIBIB) and the National Institute of General Medical Sciences (NIGMS) over the period 2003 to present. Grants R01EB1659, R01EB017205, R01GM104987, and U01EB008577.
       </p>

--- a/templates/news.html
+++ b/templates/news.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<main role="main" class="container">
+<main class="container">
 
   <div class="row">
     <div class="col-md-12 col-sm-12 col-xs-12">

--- a/templates/people.html
+++ b/templates/people.html
@@ -21,8 +21,7 @@
         Current <a href="#researchers">members</a> of the laboratory are listed below.
       </p>
 
-      <a name="researchers"></a>
-      <h2 class="site-section border-bottom">Current members</h2>
+      <h2 class="site-section border-bottom" id="researchers">Current members</h2>
 
       {% for person in people.current_members %}
         <div id="{{ person.name | replace(' ','_') }}">
@@ -30,9 +29,9 @@
           <div class="row">
             <div class="col-md-2">
               {% if person.image %} 
-              <img class="img-fluid" width="100%" src="{{ url_for('static', filename='images/' + person.image )}}" alt="{{ person.name }}">
+              <img class="img-fluid" width="120px" src="{{ url_for('static', filename='images/' + person.image )}}" alt="{{ person.name }}">
               {% else %} 
-              <img class="img-fluid" width="100%" src="{{ url_for('static', filename='images/missing.jpg' )}}" alt="{{ person.name }}">
+              <img class="img-fluid" width="120px" src="{{ url_for('static', filename='images/missing.jpg' )}}" alt="{{ person.name }}">
               {% endif %} 
             </div>
             <div class="col-md-9">

--- a/templates/physionet.html
+++ b/templates/physionet.html
@@ -20,14 +20,12 @@
   <div class="row">
     <div class="col-md-9">
 
-      <a name="Overview"></a>
-      <h2 class="site-section-meta border-bottom">Overview</h2>
+      <h2 class="site-section-meta border-bottom" id="Overview">Overview</h2>
       <p>
         The Laboratory for Computational Physiology develops and maintains PhysioNet, a widely-used repository of biomedical data and software. PhysioNet enables researchers around the world to share and reuse resources that underpin clinical studies, promoting reproducible research and lowering barriers to data access.
       </p>
 
-      <a name="Story"></a>
-      <h2 class="site-section-meta border-bottom">Story of PhysioNet</h2>
+      <h2 class="site-section-meta border-bottom" id="Story">Story of PhysioNet</h2>
       <p>
       In the mid-1970s, members of the PhysioNet team who were then working on some of the first microcomputer-based instruments for cardiac arrhythmia monitoring, foresaw the benefit of establishing shared databases of well-characterized ECG recordings, as a basis for evaluation, and objective comparison of algorithms for automated arrhythmia analysis. A five-year effort culminated in the publication of the MIT-BIH Arrhythmia Database in 1980, which soon became the standard reference collection of its type.
       </p>
@@ -41,8 +39,7 @@
       In 2019, PhysioNet was rebuilt following best practice in scientific data management and stewardship. Our goal is to promote Findability, Accessibility, Interoperability, and Reuse of PhysioNet resources (the "FAIR principles"). 
       </p>
 
-      <a name="Acknowledgments"></a>
-      <h2 class="site-section-meta border-bottom">Acknowledgments</h2>
+      <h2 class="site-section-meta border-bottom" id="Acknowledgments">Acknowledgments</h2>
       <p>
         The development and maintenance of PhysioNet has been funded by the National Institute of Biomedical Imaging and Bioengineering (NIBIB) and the National Institute of General Medical Sciences (NIGMS) over the period 2003 to present. Grants R01EB1659, R01EB017205, R01GM104987, and U01EB008577.
       </p>


### PR DESCRIPTION
The site should not raise errors or warnings when run through https://validator.w3.org/

This fixes the remaining issues on all pages except the publications page (/publications). I'm not entirely sure how this content is generated, so left that for now.

- replace name tag with the id tag for internal links
- set the images on the people page to a fix pixel width (rather than %)
- remove the unnecessary `role="main"` from the news page