### PR TITLE
Adds draft makefile for making site updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,78 @@
+.PHONY: help run update sitedata-changed deploy-staging deploy-production \
+github-update-dev github-update-staging github-update-production
+
+TEMP_DEPLOY_BRANCH = "temp-deploy"
+
+help:
+	@echo '                                                                                   '
+	@echo 'Recipes for the LCP website (http://lcp.mit.edu)                                   '
+	@echo '                                                                                   '
+	@echo 'Usage:                                                                             '
+	@echo '   make run                      Run the website locally                           '
+	@echo '   make update                   Load updates made to the sitedata folder          '
+	@echo '                                                                                   '
+
+run:
+	(source activate; flask run)
+
+update:
+	make sitedata-changed
+	# If changes are detected, commit changes on temp branch.
+	make github-update-temp
+	git checkout dev
+	# Update the dev, staging, and production branches.
+	make github-update-dev
+	# make github-update-staging
+	make github-update-production
+	# Update the live websites
+	make deploy-staging
+	make deploy-production
+	@echo '\n**************************'
+	@echo ' All updates are complete!'
+	@echo '**************************\n'
+
+sitedata-changed:
+	./sitedata-changed.sh
+
+github-update-temp:
+	@echo '\nMaking updates on a temporary branch.\n'
+	-git branch -D $(TEMP_DEPLOY_BRANCH)
+	git checkout -b $(TEMP_DEPLOY_BRANCH)
+	git add sitedata/
+	git commit -m "update sitedata with makefile."
+	@echo '\nUpdates on temporary branch complete.\n'
+
+github-update-dev:
+	@echo '\nMaking updates on the dev branch.\n'
+	git checkout dev
+	git pull origin dev
+	-git cherry-pick $(TEMP_DEPLOY_BRANCH)
+	@echo '\nUpdates on the dev branch complete.\n'
+	# git push dev
+	@echo "Pushed to dev branch on GitHub."
+
+github-update-staging:
+	@echo '\nMaking updates on the staging branch.\n'
+	git checkout staging
+	git pull origin staging
+	-git cherry-pick $(TEMP_DEPLOY_BRANCH)
+	@echo '\nUpdates on the staging branch complete.\n'
+	# git push staging
+	@echo "Pushed to staging branch on GitHub."
+	git checkout dev
+
+github-update-production:
+	@echo '\nMaking updates on the production branch.\n'
+	git checkout production
+	git pull origin production
+	-git cherry-pick $(TEMP_DEPLOY_BRANCH)
+	@echo '\nUpdates on the production branch complete.\n'
+	# git push production
+	@echo "Pushed to production branch on GitHub."
+	git checkout dev
+
+deploy-staging:
+	@echo '\nChanges deployed to the staging website.\n'
+
+deploy-production:
+	@echo '\nChanges deployed to the production website.\n'

--- a/sitedata-changed.sh
+++ b/sitedata-changed.sh
@@ -1,0 +1,11 @@
+something_changed=`git diff-index --exit-code HEAD | grep sitedata`
+
+if [ -n "$something_changed" ]
+then
+    echo >&2 "\nChanges to sitedata detected. Continuing build.\n"
+    exit 0
+else
+    echo >&2 "\nNo changes to sitedata detected. Finishing build.\n"
+    git checkout dev
+    exit 1
+fi


### PR DESCRIPTION
We would like to provide a simple(ish) way for people to update content on the website (e.g. people, news, publications). 

This makefile attempts to do that by adding a recipe that checks for changes in the sitedata folder and then (1) commits the change to github and (2) pushes the change to our servers.

Some notes:
- `make help` prints a list of available commands.
- `make run` activates a virtual environment (note that it requires a file called `activate`) and then runs the site locally.
- `make update` checks whether sitedata has been updated by calling the `sitedata-changed.sh` script. If so, it:
    - Commits the change to local branches (dev and production).
    - Pushes the change to github (commented out for now)
    - Pushes the change to our servers (not yet implemented).

I'm not convinced this is the right solution, but it's a start! Trying to automate the git steps may be a bad idea, and instead maybe we should just omit the sitedata folder from version control. Have a play around and see what you think.



