### PR TITLE
Fixes image background gradient #60

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -31,7 +31,7 @@
     background:
         linear-gradient(
             0.25turn,
-            rgba(68, 102, 170, 0.90) 50%,
+            rgba(68, 102, 170, 1.00) 50%,
             rgba(0, 0, 0, 0.01)
         ),
         url('../images/background.jpg');


### PR DESCRIPTION
Fixes the image background gradient on the home page to more resemble the color of the logo in the top left corner. Changes the gradient to start at 100% opacity instead of 90%. Fixes part of #60.