### PR TITLE
Changes contact address #60

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -24,10 +24,9 @@
       </div>
       <div class="col-md-4 col-sm-6 col-xs-12">
         <h2 class="menu_head">Contact Us</h2>
-        <p>Laboratory for Computational Physiology<br>
-        MIT, E25-505<br>
-        45 Carleton St.<br>
-        Cambridge, MA 02139</p>
+        <p>Massachusetts Institute of Technology<br>
+        77 Massachusetts Avenue<br>
+        Cambridge, MA 02139, USA</p>
         <p><a href="mailto:contact@lcp.mit.edu"><i class="fa fa-envelope">&nbsp;</i>contact@lcp.mit.edu</a><br>
         <a href="https://github.com/MIT-LCP"><i class="fa fa-github">&nbsp;</i>Github</a></p>
       </div>


### PR DESCRIPTION
Changes the address used to contact the lab from the private address to the public MIT mailing address. Fixes part of #60.