### PR TITLE
Fixes main page intro paragraph #60

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
       The Laboratory for Computational Physiology (LCP), under the direction of Professor Roger Mark, conducts research on improving health care through new and refined approaches to interpreting data.
       Some of the group’s researchers have medical backgrounds; others have backgrounds in computer science, electrical engineering, physics, or mathematics; and others have training that spans several of these disciplines.
       Current laboratory research incorporates physiology, computer science, engineering, and applied mathematics.
-      <br><br>
+    </p><p>
       Using modern approaches to modeling, signal processing, pattern recognition, and machine learning, the lab’s researchers develop and refine methods for analyzing data—for example, from patients in intensive care units—and for generating predictive models that will aid in patient care.
       Current laboratory research comprises two major projects, the <a href="mimic">MIMIC</a> project and <a href="physionet">PhysioNet</a>. See their respective pages for more detailed information.
     </p>


### PR DESCRIPTION
Fixes the research summary paragraph on the main page to split multiple paragraphes by `<p>` tags instead of `<br>` tags. Fixes part of #60.