### PR TITLE
Reduces footer title boldness #60

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -259,7 +259,7 @@
 }
 .menu_head {
     color: #000000!important;
-    font-weight: 700;
+    font-weight: 500;
     font-size: 1.125em;
     line-height: 1.5em;
 }


### PR DESCRIPTION
Reduces the `font-weight` of the titles in the footer from 700 to 500 to match the other headers. Fixes part of #60.