### PR TITLE
Fixes People Page header ordering #60.

### DIFF
--- a/templates/people.html
+++ b/templates/people.html
@@ -25,7 +25,7 @@
 
       {% for person in people.current_members %}
         <div id="{{ person.name | replace(' ','_') }}">
-          <h2 class="site-section-meta">{{ person.name }}</h2>
+          <h3 class="site-section-meta">{{ person.name }}</h3>
           <div class="row">
             <div class="col-md-2">
               {% if person.image %} 


### PR DESCRIPTION
Fixes the `h2` tag of the lab members name to an `h3` tag to stay consistent with the rest of the header tags. Fixes part of #60.