### PR TITLE
Adds skip to content links #60.

### DIFF
--- a/change.py
+++ b/change.py
@@ -176,6 +176,7 @@ def File_Change(File_Content):
   {% block content %}"""
 
   Header_HTML += """
+  <a id="skip_content"></a>
   <div class="container">
     <div class="row">
       <div class="col-md-12 col-sm-12 col-xs-12">

--- a/publications.html
+++ b/publications.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/references.css') }}">
   {% endblock %}
   {% block content %}
+  <a id="skip_content"></a>
   <div class="container">
     <div class="row">
       <div class="col-md-12 col-sm-12 col-xs-12">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,3 +1,11 @@
+.skip-to-content {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
 .form-group {
     margin-bottom: 1rem !important;
 }

--- a/templates/about.html
+++ b/templates/about.html
@@ -10,6 +10,7 @@
 
 {% block content %}
 
+<a id="skip_content"></a>
 <div class="container">
   <div class="row">
     <div class="col-md-12 col-sm-12 col-xs-12">

--- a/templates/header.html
+++ b/templates/header.html
@@ -3,6 +3,7 @@
 <meta name="keywords" content="HTML, CSS, XML, XHTML, JavaScript">
 <meta name="author" content="Felipe Torres">
 
+<a href="#skip_content" class="skip-to-content">Skip to content</a>
 <link rel="icon" href="{{ url_for('static', filename='images/lcp_favicon5.png') }}">
 
 <link rel='stylesheet' type='text/css' href="{{ url_for('static', filename='css/font-awesome.css') }}" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 
+<a id="skip_content"></a>
 <div class="container">
   <div class="jumbotron p-md-5 text-white rounded back">
     <div class="col-md-6 px-0">

--- a/templates/mimic.html
+++ b/templates/mimic.html
@@ -8,6 +8,7 @@
 
 {% block content %}
 
+<a id="skip_content"></a>
 <div class="container">
   <div class="row">
     <div class="col-md-12 col-sm-12 col-xs-12">

--- a/templates/news.html
+++ b/templates/news.html
@@ -8,6 +8,7 @@
 
 {% block content %}
 
+<a id="skip_content"></a>
 <main class="container">
 
   <div class="row">

--- a/templates/people.html
+++ b/templates/people.html
@@ -6,6 +6,8 @@
 {% endblock %}
 
 {% block content %}
+
+<a id="skip_content"></a>
 <div class="container">
   <div class="row">
 

--- a/templates/physionet.html
+++ b/templates/physionet.html
@@ -8,6 +8,7 @@
 
 {% block content %}
 
+<a id="skip_content"></a>
 <div class="container">
   <div class="row">
     <div class="col-md-12 col-sm-12 col-xs-12">

--- a/templates/publications.html
+++ b/templates/publications.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/references.css') }}">
   {% endblock %}
   {% block content %}
+  <a id="skip_content"></a>
   <div class="container">
     <div class="row">
       <div class="col-md-12 col-sm-12 col-xs-12">


### PR DESCRIPTION
Adds links at the top of each page to skip users directly to the content. This is useful for those using Lynx and Screen Readers as mentioned in #60. Fixes part of #60.