### PR TITLE
People Page: change photo alt and id #60

### DIFF
--- a/main.py
+++ b/main.py
@@ -399,11 +399,11 @@ def people():
     """
     data = _data()
 
-    path = "sitedata"
-    fn = "people.yml"
+    path = 'sitedata'
+    fn = 'people.yml'
 
     with open(os.path.join(path, fn), 'r') as f:
-        data["people"] = yaml.safe_load(f)
+        data['people'] = yaml.safe_load(f)
 
     return render_template('people.html', **data)
 

--- a/templates/people.html
+++ b/templates/people.html
@@ -25,13 +25,13 @@
 
       {% for person in people.current_members %}
         <div id="{{ person.name | replace(' ','_') }}">
-          <h2 class="site-section-meta">{{ person.name }}</h2>
+          <h3 class="site-section-meta">{{ person.name }}</h3>
           <div class="row">
             <div class="col-md-2">
               {% if person.image %} 
-              <img class="img-fluid" width="120" src="{{ url_for('static', filename='images/' + person.image )}}" alt="{{ person.name }}">
+              <img class="img-fluid" width="120" src="{{ url_for('static', filename='images/' + person.image )}}" alt="Photo of {{ person.name }}">
               {% else %} 
-              <img class="img-fluid" width="120" src="{{ url_for('static', filename='images/missing.jpg' )}}" alt="{{ person.name }}">
+              <img class="img-fluid" width="120" src="{{ url_for('static', filename='images/missing.jpg' )}}" alt="Photo of {{ person.name }}">
               {% endif %} 
             </div>
             <div class="col-md-9">


### PR DESCRIPTION
Changes the photos on the People Page to include a more descriptive alt tag: Roger Mark to photo of Roger Mark. Also changes photo id to be more descriptive: Roger_Mark to photo_of_Roger_Mark. Fixes part of #60.