### PR TITLE
Fixes sidebar squash #60

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -330,10 +330,8 @@
         padding-top: 1.5625em;
     }
 } 
-/* added by KP to override bootstrap styles */
-.col-md-3 {
-    width: 25%;
-    margin: 0;
+.p-3, .mb-3 {
+    min-width: 150px;
 }
 .row {
     margin: 0;


### PR DESCRIPTION
Fixes the sidebar being squashed when the window width is reduced. Previously, the sidebar would compress to a very small width which would not go away even if it wrapped to a new line. Now, the sidebar keeps a minimum width of `150px` while expanding if wrapped to a new line. Fixes part of #60.