### PR TITLE
Fixes skip-to-content error #60

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,11 +9,9 @@
   {% block head2 %}{% endblock %}
 </head>
 <body data-spy="scroll" data-target=".navbar-fixed-top">
+  <a href="#skip_content" class="skip-to-content">Skip to content</a>
   {% include 'navbar.html'%}
-
-
-    <div id="content">{% block content %}{% endblock %}</div>
-
+  <div id="content">{% block content %}{% endblock %}</div>
   {% include 'footer.html'%}
 
   <script>

--- a/templates/header.html
+++ b/templates/header.html
@@ -3,7 +3,6 @@
 <meta name="keywords" content="HTML, CSS, XML, XHTML, JavaScript">
 <meta name="author" content="Felipe Torres">
 
-<a href="#skip_content" class="skip-to-content">Skip to content</a>
 <link rel="icon" href="{{ url_for('static', filename='images/lcp_favicon5.png') }}">
 
 <link rel='stylesheet' type='text/css' href="{{ url_for('static', filename='css/font-awesome.css') }}" />


### PR DESCRIPTION
Fixes the error where the `skip-to-content` link was inserted before the valid HTML began which cause W3C errors. Now, the link is inserted immeditally after the start of the body tag. Fixes part of #60.