### PR TITLE
Adds news scrolling #60

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,3 +1,10 @@
+.news_box {
+    height: 300px;
+}
+.news_box p {
+    overflow-y: auto;
+    max-height: 200px;
+}
 .skip-to-content {
     position: absolute;
     left: -10000px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,12 +39,11 @@
         {% if post.front_page %}
           <div class="col-md-6">
             <div class="row no-gutters border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
-              <div class="col p-4 d-flex flex-column position-static">
+              <div class="news_box col p-4 d-flex flex-column position-static">
                 <strong class="d-inline-block mb-2 text-success">{{ post.header }}</strong>
                 <h3 class="mb-0">{{ post.title }}</h3>
                 <div class="mb-1 text-muted">{{ post.date }}</div>
-                <p class="card-text">{{ post.content | safe | truncate(200)}}</p>
-                <a href="news" class="card-link">Continue reading</a>
+                <p class="card-text">{{ post.content | safe }}</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Adds scrolling functionality to the front page news items. Links to the news page are removed since they did not lead to the correct page. News box items are set to a rigid height and the inside text is set to scroll if needed while keeping content such as the title and date static. Fixes part of #60.