### PR TITLE
Generates new page for each news item #60

### DIFF
--- a/main.py
+++ b/main.py
@@ -418,6 +418,24 @@ def news():
     return render_template('news.html', **data)
 
 
+@app.route("/<news_id>")
+def news_item(news_id):
+    """
+    Display an individual news item.
+    """
+    news = get_news_data()
+
+    post = [x for x in news['news']['news_items']
+            if x['post_number'] == news_id]
+
+    if post:
+        data = {}
+        data['post'] = post[0]
+        return render_template("news_post.html", **data)
+    else:
+        return render_template('404.html')
+
+
 if __name__ == "__main__":
     app.jinja_env.auto_reload = True
     app.run(host='0.0.0.0', port=8083, threaded=True, debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,7 +44,7 @@
                 <h3 class="mb-0">{{ post.title }}</h3>
                 <div class="mb-1 text-muted">{{ post.date }}</div>
                 <p class="card-text">{{ post.content | safe | truncate(200)}}</p>
-                <a href="news" class="card-link">Continue reading</a>
+                <a href="{{ post.post_number }}" class="card-link">Continue reading</a>
               </div>
             </div>
           </div>

--- a/templates/news.html
+++ b/templates/news.html
@@ -45,7 +45,9 @@
                 <h2 class="site-section-meta">{{ post.title }}</h2>
                 <h2 class="site-section-sub">{{ post.date }}</h2>
                 <p>{{ post.content | safe }}</p>
-                <p><a href="{{ post.url }}">Read more..</a></p>
+                {% if post.url %}
+                  <p><a href="{{ post.url }}">Read more..</a></p>
+                {% endif %}
               </div>
             {% endif %}
           {% endfor %}

--- a/templates/news_post.html
+++ b/templates/news_post.html
@@ -1,10 +1,7 @@
 {% set active_page = "News" %}
 {% extends "base.html" %}
 {% block title %}Laboratory for Computational Physiology{% endblock %}
-{% block head2 %}
-<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/publications.css') }}">
-<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/references.css') }}">
-{% endblock %}
+{% block head2 %}{% endblock %}
 
 {% block content %}
 

--- a/templates/news_post.html
+++ b/templates/news_post.html
@@ -1,0 +1,33 @@
+{% set active_page = "News" %}
+{% extends "base.html" %}
+{% block title %}Laboratory for Computational Physiology{% endblock %}
+{% block head2 %}
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/publications.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/references.css') }}">
+{% endblock %}
+
+{% block content %}
+
+<a id="skip_content"></a>
+<main class="container">
+
+  <div class="row">
+    <div class="col-md-12 col-sm-12 col-xs-12">
+      <div class="text-left">
+        <h1 class="site-section-title">{{ post.title }}</h1>
+      </div>
+    </div>
+  </div>
+
+  <div class='row'>
+
+    <div class="col-md-12">
+      <h2>{{ post.date }}</h2>
+      <p>{{ post.content | safe }}</p>
+    </div>
+
+  </div>
+
+</main>
+
+{% endblock %}


### PR DESCRIPTION
Automatically generates a new page for each news item. This means that the `continue reading` link on the home page now correctly links to an expanded form of the news item presented on the home page. Further, adds some error protection on the actual news page by allowing the external URL link to be optional. Fixes part of #60.