### PR TITLE
Adds make publications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ run:
 	(source activate; flask run)
 
 update:
+	# Update the publications
+	./scripts/change.py
+	# Determine if changes are detected in the sitedata folder
 	make sitedata-changed
 	# If changes are detected, commit changes on temp branch.
 	make github-update-temp


### PR DESCRIPTION
Adds the ability to update publications using the `Makefile`. By running `make publications`, the user runs the `change.py` script and then runs `make update` which updates the changes to Github. For now, the `make update` section is commented out until development is finished so accidental changes don't get pushed to Github.