### PR TITLE
Adds post-receive

### DIFF
--- a/deploy/post-receive
+++ b/deploy/post-receive
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+install_dir=/var/www/vhosts/lcp.mit.edu/lcp-website
+log_file=/data/log/lcp-website/update.log
+branch=production
+
+# If the following commands fail, it is too late to abort the push.
+# Try to avoid doing things that might fail!
+
+echo "$(date '+%F %T %z'): $branch: post-receive started" >> $log_file
+exec 3>&1
+exec &> >(tee -a $log_file)
+
+# Install into /var/www/vhosts/lcp.mit.edu/lcp-website
+echo "* Installing new server code..."
+GIT_WORK_TREE=$install_dir git checkout --force "$branch" 2>> $log_file
+
+# Restart the uwsgi server
+echo "* Reloading uwsgi server..."
+# Could do 'sudo symstemctl restart uwsgi.service' but floods logs
+sudo touch /etc/uwsgi.d/wsgi_lcp.ini
+
+echo "$(date '+%F %T %z'): $branch: post-receive finished" >> $log_file
+echo >> $log_file


### PR DESCRIPTION
Adds `post-receive` file to the repository as taken from the server. Basic overview:

1. A `push` is received to the repository from anywhere (typically a local clone for this case)
2. The contents of the new `push` are checked-out 
3. The Flask app is restarted by restarting its specific UWSGI configuration