### PR TITLE
Removes research summary

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,17 +22,6 @@
 
 <div class="container">
   <div class="col-md-12">
-    <h2 class="site-section-meta border-bottom">Research Summary</h2>
-    <p>
-      The Laboratory for Computational Physiology (LCP), under the direction of Professor Roger Mark, conducts research on improving health care through new and refined approaches to interpreting data.
-      Some of the group’s researchers have medical backgrounds; others have backgrounds in computer science, electrical engineering, physics, or mathematics; and others have training that spans several of these disciplines.
-      Current laboratory research incorporates physiology, computer science, engineering, and applied mathematics.
-    </p><p>
-      Using modern approaches to modeling, signal processing, pattern recognition, and machine learning, the lab’s researchers develop and refine methods for analyzing data—for example, from patients in intensive care units—and for generating predictive models that will aid in patient care.
-      Current laboratory research comprises two major projects, the <a href="mimic">MIMIC</a> project and <a href="physionet">PhysioNet</a>. See their respective pages for more detailed information.
-    </p>
-  </div>
-  <div class="col-md-12">
     <h1 class="site-section-meta border-bottom">Latest News</h1>
     <div class="row">
       {% for post in news.news_items %}


### PR DESCRIPTION
Removes the research summary from the Home page since it is repeated text from the About page.