### PR TITLE
Removes contact info indent

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -35,19 +35,16 @@
       </p>
 
       <h2 class="site-section-meta border-bottom" id="Contact">Contact</h2>
-      <div class="col-md-12">
-        <div class="text-left">
-          <p>
-            Laboratory for Computational Physiology<br>
-            Massachusetts Institute of Technology, E25-505<br>
-            77 Massachusetts Avenue<br>
-            Cambridge, MA 02139, USA
-          </p>
-          <p>
-            You may contact Prof. Roger Mark at MIT extension 3-7818, or via his MIT e-mail address.
-          </p>
-        </div>
-      </div>
+      <p>
+        Laboratory for Computational Physiology<br>
+        Massachusetts Institute of Technology, E25-505<br>
+        77 Massachusetts Avenue<br>
+        Cambridge, MA 02139, USA
+      </p>
+      <p>
+        You may contact Prof. Roger Mark at MIT extension 3-7818, or via his MIT e-mail address.
+      </p>
+
     </div>
     <aside class="col-md-3">
       <div class="p-3 mb-3 bg-light rounded">


### PR DESCRIPTION
Removes the indentation for the contact information on the About page. This makes it more in-line and consistent with the style used on the rest of the page.