### PR TITLE
use /home instead of /index.html for homepage

### DIFF
--- a/main.py
+++ b/main.py
@@ -286,6 +286,7 @@ def submit():
 #
 ###############################################################################
 @app.route("/")
+@app.route("/home")
 @app.route("/index")
 @app.route("/index.html")
 @app.route("/index.shtml")

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -7,16 +7,16 @@
   <header class="site-header py-4">
     <div class="row flex-nowrap justify-content-between align-items-center">
       <div class="col-md-1">
-        <a href="index.html"><img class="img-fluid header_img" src="{{ url_for('static', filename='images/lcp_logo.png') }}" alt="Laboratory for Computational Physiology"></a>
+        <a href="home"><img class="img-fluid header_img" src="{{ url_for('static', filename='images/lcp_logo.png') }}" alt="Laboratory for Computational Physiology"></a>
       </div>
       <div class="col-md-10 text-primary">
-        <a class="site-header-logo text-dark" href="index.html">Laboratory for Computational Physiology</a>
+        <a class="site-header-logo text-dark" href="home">Laboratory for Computational Physiology</a>
       </div>
     </div>
   </header>
 
   {% set navigation_bar = [
-    ('index.html', 'Home'),
+    ('home', 'Home'),
     ('about', 'About'),
     ('people', 'People'),
     ('physionet', 'PhysioNet'),


### PR DESCRIPTION
The default URL for the homepage is: https://lcp.mit.edu/index.html. `/home` would be friendlier and consistent with the URLs for other pages (e.g. https://lcp.mit.edu/about, https://lcp.mit.edu/people, etc).

This is a minor change to switch the homepage to https://lcp.mit.edu/home. `index.html` will continue to render the homepage for now, but it could be redirected to `/home` later.