### PR TITLE
Evaluates variables as list not as strings

### DIFF
--- a/deploy/etc/uwsgi.d/wsgi_lcp.ini
+++ b/deploy/etc/uwsgi.d/wsgi_lcp.ini
@@ -11,7 +11,7 @@ processes = 5
 gid = publicusers
 
 socket = /etc/uwsgi.sockets/lcp_uwsgi.sock
-venv = /var/www/vhosts/lcp.mit.edu/python3_env
+venv = /var/www/vhosts/lcp.mit.edu/env3
 
 #logto = /var/log/uwsgi/%n.log
 req-logger = file:/var/log/uwsgi/%n-req.log

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,5 +1,6 @@
 # Import necessary packages
 import os
+import ast
 
 from dotenv import load_dotenv
 
@@ -25,8 +26,8 @@ class Config:
 
     # Admin configuration
     ADMIN = os.environ.get('ADMIN')
-    EMAIL_RECIPIENTS = os.environ.get('EMAIL_RECIPIENTS')
-    PRIMARY_ADMIN = os.environ.get('PRIMARY_ADMIN')
+    EMAIL_RECIPIENTS = ast.literal_eval(os.environ.get('EMAIL_RECIPIENTS'))
+    PRIMARY_ADMIN = ast.literal_eval(os.environ.get('PRIMARY_ADMIN'))
 
 
 # Config used for development


### PR DESCRIPTION
There was a 502 error in which the env variables are loaded all as strings. Here we add the lists as lists.