### PR TITLE
Reverts to default link color and Helvetica font

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -35,6 +35,12 @@
     text-decoration: underline;
     cursor: pointer;
 } */
+a {
+    color: #0000EE;
+}
+body {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+}
 .back {
     background:
         linear-gradient(


### PR DESCRIPTION
This change reverts back to the default link color pre-Boostrap and also changes the default body font to Helvetica Neue, Arial, sans-serif to increase readability. 